### PR TITLE
PLYO-723 Log node environment.

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -13,5 +13,8 @@ module.exports = {
           forceColor: true,
         },
     level: process.env.LOG_LEVEL || 'debug',
+    base: {
+      nodeEnv: process.env.NODE_ENV,
+    },
   },
 };


### PR DESCRIPTION
QA notes.
To check three items:
 - nodeEnv key is present at the top level of every log document from production DB service (it is ok to check a couple of documents)
 - the nodeEnv equals `production` for every log document from production DB service (it is ok to check a couple o document)
 - nodeEnv key is present at the top level of every log document from non-production DB service (it is ok to check a couple o document from stage servers) and not equal `production`
